### PR TITLE
EncodeClip: Bump version inside script

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -158,7 +158,7 @@
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "93ed04e8070059b7eeea991414a4b13d1f4a065b"
+              "sha1": "d553472fcc8f1b8282966efdbdc3cdbbed69a087"
             }
           ],
           "requiredModules": [

--- a/macros/petzku.EncodeClip.lua
+++ b/macros/petzku.EncodeClip.lua
@@ -36,7 +36,7 @@ script_name = tr'Encode Clip'
 script_description = tr'Encode various clips from the current selection'
 script_author = 'petzku'
 script_namespace = "petzku.EncodeClip"
-script_version = '0.8.0'
+script_version = '0.8.1'
 
 
 local haveDepCtrl, DependencyControl, depctrl = pcall(require, "l0.DependencyControl")


### PR DESCRIPTION
Version inside the Encode Clip script didn't get bumped causing depctrl to re-download the script on every update check.