### PR TITLE
[modules/util] io.run_cmd: Fix missing " in command on Unix (0.4.1)

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -466,14 +466,14 @@
       "description": "Various utility functions for use with petzku's Aegisub macros",
       "channels": {
         "stable": {
-          "version": "0.4.0",
-          "released": "2022-09-04",
+          "version": "0.4.1",
+          "released": "2023-07-18",
           "default": true,
           "files": [
             {
               "name": ".moon",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "3def7b96613ce775e9e7debec3ca9804f3710c68"
+              "sha1": "2372f0905257d0c5531cbc6de56a9ed5eb08c561"
             },
             {
               "name": "/tee.exe",
@@ -487,7 +487,8 @@
       "changelog": {
         "0.2.0": ["Add IO functionality", "Add to DependencyControl"],
         "0.3.0": ["Add \\t, \\move, \\fad retiming"],
-        "0.4.0": ["Upgrade run_cmd in a way that handles stderr"]
+        "0.4.0": ["Upgrade run_cmd in a way that handles stderr"],
+        "0.4.1": ["Fix typo in run_cmd on Unix"]
       }
     }
   }

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -146,14 +146,14 @@
       "description": "Encode a hardsubbed clip encompassing the current selection",
       "channels": {
         "stable": {
-          "version": "0.8.4",
-          "released": "2023-07-04",
+          "version": "0.8.5",
+          "released": "2023-07-18",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "2a8507b1dd1bb2fb333ca3b96499d10723b2e0f4"
+              "sha1": "b9648ab4a44c2213ee9ec073f606772258e5ffb0"
             }
           ],
           "requiredModules": [
@@ -161,7 +161,7 @@
               "moduleName": "petzku.util",
               "name": "petzkuLib",
               "url": "https://github.com/petzku/Aegisub-Scripts",
-              "version": "0.3.0"
+              "version": "0.4.1"
             }
           ]
         }
@@ -203,7 +203,8 @@
         ],
         "0.8.4": [
           "Fix handling of audio when from a file different from the video"
-        ]
+        ],
+        "0.8.5": ["Bump util dependency to 0.4.1"]
       }
     },
     "petzku.ExtrapolateMove": {

--- a/macros/petzku.EncodeClip.lua
+++ b/macros/petzku.EncodeClip.lua
@@ -36,7 +36,7 @@ script_name = tr'Encode Clip'
 script_description = tr'Encode various clips from the current selection'
 script_author = 'petzku'
 script_namespace = "petzku.EncodeClip"
-script_version = '0.8.4'
+script_version = '0.8.5'
 
 
 local haveDepCtrl, DependencyControl, depctrl = pcall(require, "l0.DependencyControl")
@@ -45,7 +45,7 @@ if haveDepCtrl then
     depctrl = DependencyControl {
         feed="https://raw.githubusercontent.com/petzku/Aegisub-Scripts/stable/DependencyControl.json",
         {
-            {"petzku.util", version="0.3.0", url="https://github.com/petzku/Aegisub-Scripts",
+            {"petzku.util", version="0.4.1", url="https://github.com/petzku/Aegisub-Scripts",
              feed="https://raw.githubusercontent.com/petzku/Aegisub-Scripts/stable/DependencyControl.json"},
             {"a-mo.ConfigHandler", version="1.1.4", url="https://github.com/TypesettingTools/Aegisub-Motion",
              feed="https://raw.githubusercontent.com/TypesettingTools/Aegisub-Motion/DepCtrl/DependencyControl.json"}

--- a/modules/petzku/util.moon
+++ b/modules/petzku/util.moon
@@ -12,7 +12,7 @@ local util, re
 if haveDepCtrl
     depctrl = DependencyControl {
         name: 'petzkuLib',
-        version: '0.4.0',
+        version: '0.4.1',
         description: [[Various utility functions for use with petzku's Aegisub macros]],
         author: "petzku",
         url: "https://github.com/petzku/Aegisub-Scripts",
@@ -139,7 +139,7 @@ with lib
                 f = io.open runner_path, 'w'
                 f\write "#!/bin/sh\n"
                 f\write "mkfifo \"#{pipe_path}\"\n"
-                f\write "tee \"#{output_path} <\"#{pipe_path}\" &\n"
+                f\write "tee \"#{output_path}\" <\"#{pipe_path}\" &\n"
                 f\write "#{cmd} >\"#{pipe_path}\" 2>&1\n"
                 f\write "exit $?\n"
                 f\close!


### PR DESCRIPTION
Also bumps Encode Clip to use this new version