### PR TITLE
[EncodeClip] Refactor command-line building, improve config menu

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -147,14 +147,14 @@
       "description": "Encode a hardsubbed clip encompassing the current selection",
       "channels": {
         "stable": {
-          "version": "0.8.5",
-          "released": "2023-07-18",
+          "version": "0.9.0",
+          "released": "2023-11-20",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "b9648ab4a44c2213ee9ec073f606772258e5ffb0"
+              "sha1": "3540545a02e4ce427874a6796b064f0bd2ca31cd"
             }
           ],
           "requiredModules": [
@@ -205,7 +205,14 @@
         "0.8.4": [
           "Fix handling of audio when from a file different from the video"
         ],
-        "0.8.5": ["Bump util dependency to 0.4.1"]
+        "0.8.5": ["Bump util dependency to 0.4.1"],
+        "0.9.0": [
+          "Add option in config to default to a certain audio track ID (disabled by default)",
+          "Refactor command generation logic",
+          "Fix some issues with default mpv options",
+          "Change GUI Config and Cancel hotkeys (from G/C to C/N)",
+          "Improve Config GUI order and labels"
+        ]
       }
     },
     "petzku.ExtrapolateMove": {

--- a/macros/petzku.EncodeClip.lua
+++ b/macros/petzku.EncodeClip.lua
@@ -111,7 +111,8 @@ You can put options on separate lines, but all options must be prefixed with --
         audio_command = {
             class='textbox', value="", config=true,
             x=0, y=8, width=20, height=3,
-            hint=[[Custom command line options passed to mpv when encoding only audio.]]
+            hint=[[Custom command line options passed to mpv when encoding only audio.
+Options here do NOT get applied when encoding video, whether it has audio or not.]]
         }
     }
 }

--- a/macros/petzku.EncodeClip.lua
+++ b/macros/petzku.EncodeClip.lua
@@ -68,51 +68,50 @@ local config_diag = {
             hint=[[Path to the mpv executable.
 If left blank, searches system PATH.]]
         },
-        video_command_label = {
-            class='label', label='Custom mpv options for video clips:',
-            x=0, y=1, width=10, height=1
-        },
-        video_command = {
-            class='textbox', value="", config=true,
-            x=0, y=2, width=20, height=3,
-            hint=[[Custom command line options flags passed to mpv when encoding video.
-You can put options on separate lines, but all options must be prefixed with --. (e.g. "--aid=2" to pick the second audio track in the file)]]
-        },
         audio_encoder_label = {
             class='label', label='Audio encoder. Defaults to best available AAC.',
-            x=0, y=5, width=10, height=1
+            x=0, y=1, width=10, height=1
         },
         audio_encoder = {
             class='edit', value="", config=true,
-            x=10, y=5, width=10, height=1,
+            x=10, y=1, width=10, height=1,
             hint=[[Audio encoder to use.
 If left blank, automatically picks the best available AAC encoder.
 Note that you may need to change --oacopts if you use a non-AAC encoder.]]
         },
-        audio_command_label = {
-            class='label', label='Custom mpv options for audio-only clips:',
-            x=0, y=6, width=10, height=1
-        },
-        audio_command = {
-            class='textbox', value="", config=true,
-            x=0, y=7, width=20, height=3,
-            hint=[[Custom command line options passed to mpv when encoding only audio.]]
-        },
         use_aid = {
             class='checkbox', value=false, config=true,
             label='&Audio track to use (only applies if checkbox checked)',
-            -- x=0, y=10, width = 1, height = 1,
-            x=0, y=10, width = 15, height = 1,
+            x=0, y=2, width = 15, height = 1,
             hint=[[Enable forcing audio track.
 If unset, mpv will fallback to its defaults (which might decide based on user locale), unless the settings above override it.
 If set, the value given to the right will be supplied to --aid.]]
         },
         aid = {
             class='intedit', value=2, config=true, min=1, max=128,
-            x=15, y=10, width=5, height=1,
+            x=15, y=2, width=5, height=1,
             hint=[[Audio track ID to use.
 Supplied to mpv as --aid, so this is indexed starting from 1. Supplying an out-of-bounds track ID will cause no audio to be included.
 If you want to consistently select by language, just use --alang in the config sections above.]]
+        },
+        video_command_label = {
+            class='label', label='Custom mpv options for video clips:',
+            x=0, y=3, width=10, height=1
+        },
+        video_command = {
+            class='textbox', value="", config=true,
+            x=0, y=4, width=20, height=3,
+            hint=[[Custom command line options flags passed to mpv when encoding video.
+You can put options on separate lines, but all options must be prefixed with --. (e.g. "--aid=2" to pick the second audio track in the file)]]
+        },
+        audio_command_label = {
+            class='label', label='Custom mpv options for audio-only clips:',
+            x=0, y=7, width=10, height=1
+        },
+        audio_command = {
+            class='textbox', value="", config=true,
+            x=0, y=8, width=20, height=3,
+            hint=[[Custom command line options passed to mpv when encoding only audio.]]
         }
     }
 }

--- a/macros/petzku.EncodeClip.lua
+++ b/macros/petzku.EncodeClip.lua
@@ -272,13 +272,23 @@ local function build_cmd(user_opts, ...)
         '"%s"',
         '--o="%s"',
         -- all options supplied as varargs
-        table.concat(opts, ' '),
-        -- user options
-        -- these parentheses are required to drop the "made X replacements" return value of gsub.
-        -- in the middle of list construction, from a single "entry".
-        -- this is the worst feature ever.
-        (user_opts:gsub("\n", " "))
+        table.concat(opts, ' ')
     }
+
+    -- force audio track
+    local cfg = get_configuration()
+    if cfg.use_aid then
+        table.insert(cmd_table, "--aid=" .. cfg.aid)
+    end
+
+    -- user options, if relevant. these are allowed to override aid setting above
+    if user_opts and user_opts ~= "" then
+        -- these extra parentheses are required to drop the "made X replacements" return value of gsub.
+        -- which gives table.insert a third argument, and makes it error since the second argument is an optional index.
+        -- in the middle of a function call, from what should by all rights be a single argument.
+        -- this is the worst feature ever.
+        table.insert(cmd_table, (user_opts:gsub("\n", " ")))
+    end
 
     return table.concat(cmd_table, ' ')
 end

--- a/macros/petzku.EncodeClip.lua
+++ b/macros/petzku.EncodeClip.lua
@@ -60,12 +60,13 @@ local config_diag = {
     main = {
         exe_label = {
             class='label', label="mpv path:",
-            x=0, y=0, width=5, height=1
+            x=0, y=0, width=2, height=1
         },
         mpv_exe = {
             class='edit', value="", config=true,
-            x=5, y=0, width=15, height=1,
-            hint=[[Path to the mpv executable. If left blank, searches system PATH.]]
+            x=2, y=0, width=18, height=1,
+            hint=[[Path to the mpv executable.
+If left blank, searches system PATH.]]
         },
         video_command_label = {
             class='label', label='Custom mpv options for video clips:',
@@ -74,16 +75,19 @@ local config_diag = {
         video_command = {
             class='textbox', value="", config=true,
             x=0, y=2, width=20, height=3,
-            hint=[[Custom command line options flags passed to mpv when encoding video. You can put options on separate lines, but all options must be prefixed with --. (e.g. "--aid=2" to pick the second audio track in the file)]]
+            hint=[[Custom command line options flags passed to mpv when encoding video.
+You can put options on separate lines, but all options must be prefixed with --. (e.g. "--aid=2" to pick the second audio track in the file)]]
         },
         audio_encoder_label = {
             class='label', label='Audio encoder. Defaults to best available AAC.',
-            x=0, y=5, width=5, height=1
+            x=0, y=5, width=10, height=1
         },
         audio_encoder = {
             class='edit', value="", config=true,
-            x=5, y=5, width=15, height=1,
-            hint="Audio encoder to use. If left blank, automatically picks the best available AAC encoder.\nNote that you may need to change --oacopts if you use a non-AAC encoder."
+            x=10, y=5, width=10, height=1,
+            hint=[[Audio encoder to use.
+If left blank, automatically picks the best available AAC encoder.
+Note that you may need to change --oacopts if you use a non-AAC encoder.]]
         },
         audio_command_label = {
             class='label', label='Custom mpv options for audio-only clips:',
@@ -93,6 +97,22 @@ local config_diag = {
             class='textbox', value="", config=true,
             x=0, y=7, width=20, height=3,
             hint=[[Custom command line options passed to mpv when encoding only audio.]]
+        },
+        use_aid = {
+            class='checkbox', value=false, config=true,
+            label='&Audio track to use (only applies if checkbox checked)',
+            -- x=0, y=10, width = 1, height = 1,
+            x=0, y=10, width = 15, height = 1,
+            hint=[[Enable forcing audio track.
+If unset, mpv will fallback to its defaults (which might decide based on user locale), unless the settings above override it.
+If set, the value given to the right will be supplied to --aid.]]
+        },
+        aid = {
+            class='intedit', value=2, config=true, min=1, max=128,
+            x=15, y=10, width=5, height=1,
+            hint=[[Audio track ID to use.
+Supplied to mpv as --aid, so this is indexed starting from 1. Supplying an out-of-bounds track ID will cause no audio to be included.
+If you want to consistently select by language, just use --alang in the config sections above.]]
         }
     }
 }
@@ -278,8 +298,8 @@ function make_clip(subs, sel, hardsub, audio)
     if hardsub and aegisub.gui and aegisub.gui.is_modified and aegisub.gui.is_modified() then
         -- warn user about script not being saved
         if not GUI.show_user_warning("File not saved!", [[Current script file has not been saved.
-        You probably wanted to save first.
-        Press Enter to proceed anyway, or Escape to cancel.]], "Encode &anyway") then
+You probably wanted to save first.
+Press Enter to proceed anyway, or Escape to cancel.]], "Encode &anyway") then
             return
         end
     end

--- a/macros/petzku.EncodeClip.lua
+++ b/macros/petzku.EncodeClip.lua
@@ -36,7 +36,7 @@ script_name = tr'Encode Clip'
 script_description = tr'Encode various clips from the current selection'
 script_author = 'petzku'
 script_namespace = "petzku.EncodeClip"
-script_version = '0.8.5'
+script_version = '0.9.0'
 
 
 local haveDepCtrl, DependencyControl, depctrl = pcall(require, "l0.DependencyControl")
@@ -279,7 +279,9 @@ function make_clip(subs, sel, hardsub, audio)
     local sub_opts
     if hardsub then
         sub_opts = table.concat({
-            '--sub-font-provider=auto',
+            '--slang=',
+            '--no-sub-auto',
+            '--subs-with-matching-audio=yes',
             '--sub-file="%s"'
         }, ' '):format(subfile)
     else
@@ -292,6 +294,7 @@ function make_clip(subs, sel, hardsub, audio)
 
     local commands = {
         mpv_exe,
+        '--no-config',
         '--start=%.3f',
         '--end=%.3f',
         '"%s"',
@@ -323,6 +326,7 @@ function make_audio_clip(subs, sel)
 
     local commands = {
         mpv_exe,
+        '--no-config',
         '--start=%.3f',
         '--end=%.3f',
         '"%s"',

--- a/macros/petzku.EncodeClip.lua
+++ b/macros/petzku.EncodeClip.lua
@@ -101,7 +101,7 @@ If you want to consistently select by language, just use --alang in the config s
         video_command = {
             class='textbox', value="", config=true,
             x=0, y=4, width=20, height=3,
-            hint=[[Custom command line options flags passed to mpv when encoding video.
+            hint=[[Custom command line options passed to mpv when encoding video.
 You can put options on separate lines, but all options must be prefixed with --. (e.g. "--aid=2" to pick the second audio track in the file)]]
         },
         audio_command_label = {

--- a/macros/petzku.EncodeClip.lua
+++ b/macros/petzku.EncodeClip.lua
@@ -137,8 +137,8 @@ local GUI = {
     BUTTONS = {
         AUDIO = tr"Audio-&only clip",
         VIDEO = tr"&Video clip",
-        CONFIG = tr"Confi&g",
-        CANCEL = tr"&Cancel"
+        CONFIG = tr"&Config",
+        CANCEL = tr"Ca&ncel"
     },
     show_user_warning = function(title, desc, proceed)
         return aegisub.dialog.display(
@@ -146,8 +146,8 @@ local GUI = {
                 {class="label", label=title, x=0, y=0},
                 {class="label", label=desc, x=0, y=1}
             },
-            {proceed, "&Cancel"},
-            {ok = proceed, cancel = "&Cancel"}
+            {proceed, "Ca&ncel"},
+            {ok = proceed, cancel = "Ca&ncel"}
         )
     end
 }


### PR DESCRIPTION
Condenses logic further between `make_clip` and `make_audio_clip`.

Changes to default options:
- Supply `--no-config`
- Fix `--slang=auto` disabling subs on newer mpv versions

Config changes:
- Remove default user command value of `--sub-font-provider=auto`
  - this was already forced for a few versions, and `--no-config` now makes it wholly unnecessary
- Add audio track selection setting for convenience
- Change hotkey for config menu from G to C ("cancel" became N instead)
- Improve explanations on some labels