### PR TITLE
[util] io: Use slashes on all platforms in aegisub.decode_path

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -162,7 +162,7 @@
               "moduleName": "petzku.util",
               "name": "petzkuLib",
               "url": "https://github.com/petzku/Aegisub-Scripts",
-              "version": "0.4.1"
+              "version": "0.4.4"
             }
           ]
         }
@@ -524,14 +524,14 @@
       "description": "Various utility functions for use with petzku's Aegisub macros",
       "channels": {
         "stable": {
-          "version": "0.4.3",
-          "released": "2023-11-19",
+          "version": "0.4.4",
+          "released": "2025-01-21",
           "default": true,
           "files": [
             {
               "name": ".moon",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "1655512e006c654458a63ffad432309984b5a7dc"
+              "sha1": "3aec6adea2cb938480cd22d51930ff626ccfde2e"
             },
             {
               "name": "/tee.exe",
@@ -550,7 +550,8 @@
         "0.4.2": [
           "Transforms: change both-negative-times move to pos tag instead"
         ],
-        "0.4.3": ["Include feed URL for DepCtrl updating"]
+        "0.4.3": ["Include feed URL for DepCtrl updating"],
+        "0.4.4": ["Fix decode_path breaking on Windows with Aegisub 3.4.2"]
       }
     }
   }

--- a/modules/petzku/util.moon
+++ b/modules/petzku/util.moon
@@ -12,7 +12,7 @@ local util, re
 if haveDepCtrl
     depctrl = DependencyControl {
         name: 'petzkuLib',
-        version: '0.4.3',
+        version: '0.4.4',
         description: [[Various utility functions for use with petzku's Aegisub macros]],
         author: "petzku",
         url: "https://github.com/petzku/Aegisub-Scripts",
@@ -119,8 +119,8 @@ with lib
             if pathsep == '\\'
                 -- windows
                 -- command lines over 256 bytes don't get run correctly, make a temporary file as a workaround
-                runner_path = aegisub.decode_path('?temp' .. pathsep .. 'petzku.bat')
-                wrapper_path = aegisub.decode_path('?temp' .. pathsep .. 'petzku-wrapper.bat')
+                runner_path = aegisub.decode_path('?temp/petzku.bat')
+                wrapper_path = aegisub.decode_path('?temp/petzku-wrapper.bat')
                 exit_code_path = os.tmpname()
                 -- provided by https://sourceforge.net/projects/unxutils/
                 tee_path = "#{re.match(debug.getinfo(1).source, '@?(.*[/\\\\])')[1].str}util/tee"
@@ -138,7 +138,7 @@ with lib
                 f\write "exit /b %errorlevel%\n"
                 f\close!
             else
-                runner_path = aegisub.decode_path('?temp' .. pathsep .. 'petzku.sh')
+                runner_path = aegisub.decode_path('?temp/petzku.sh')
                 pipe_path = os.tmpname()
                 -- create shell script
                 f = io.open runner_path, 'w'


### PR DESCRIPTION
There is no real reason to use backslashes, and apparently 3.4.2 broke this (thanks std::filesystem)
