### PR TITLE
[EncodeClip] Remove legacy `--slang` options

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -147,14 +147,14 @@
       "description": "Encode a hardsubbed clip encompassing the current selection",
       "channels": {
         "stable": {
-          "version": "1.1.1",
-          "released": "2024-06-25",
+          "version": "1.1.2",
+          "released": "2025-01-30",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "8f40bac891ee02d107520b69080712c2323f872a"
+              "sha1": "d5f7621268efb4b548a02ca38b0da403b17dfb50"
             }
           ],
           "requiredModules": [
@@ -173,7 +173,8 @@
           "Add dummy video encoding using lavfi (doesn't support checkerboard)"
         ],
         "1.1.0": ["Option for adding short context to clips"],
-        "1.1.1": ["Force --ovc=libx264"]
+        "1.1.1": ["Force --ovc=libx264"],
+        "1.1.2": ["Remove legacy --slang settings"]
       }
     },
     "petzku.ExtrapolateMove": {

--- a/macros/petzku.EncodeClip.lua
+++ b/macros/petzku.EncodeClip.lua
@@ -36,7 +36,7 @@ script_name = tr'Encode Clip'
 script_description = tr'Encode various clips from the current selection'
 script_author = 'petzku'
 script_namespace = "petzku.EncodeClip"
-script_version = '1.1.1'
+script_version = '1.1.2'
 
 
 local haveDepCtrl, DependencyControl, depctrl = pcall(require, "l0.DependencyControl")
@@ -381,9 +381,6 @@ Press Enter to proceed anyway, or Escape to cancel.]], "Encode &anyway") then
     local sub_opts
     if hardsub then
         sub_opts = {
-            '--slang=',
-            '--no-sub-auto',
-            '--subs-with-matching-audio=yes',
             string.format('--sub-file="%s"', subfile)
         }
     else


### PR DESCRIPTION
Formerly, `--slang=` (or `--slang-clr`) was required so mpv's language autoselection didn't de-select the track from --sub-file.
This has long since been fixed, and though the options aren't doing much harm, I see no real reason to keep them around (besides supporting old mpv builds)

Shortly before writing, mpv latest master in fact broke this `--slang=` form, though `--slang-clr` should still work fine. At time of writing, a PR to restore this functionality exists, and so is very unlikely to see release (or even a nightly build). Nevertheless, I now consider this legacy code, especially as apparently the "broken" selection logic that originally required these was never a part of any stable release.