### PR TITLE
[util] run_cmd: Fix always logging errors (0.5.1)

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -550,14 +550,14 @@
       "description": "Various utility functions for use with petzku's Aegisub macros",
       "channels": {
         "stable": {
-          "version": "0.5.0",
-          "released": "2025-09-28",
+          "version": "0.5.1",
+          "released": "2025-10-16",
           "default": true,
           "files": [
             {
               "name": ".moon",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "f3af4867bc19e4096dcd163aedc276789d24e54c"
+              "sha1": "0755d4c089ac064cb42948247933799b7155ff6e"
             },
             {
               "name": "/tee.exe",
@@ -582,7 +582,8 @@
           "Add logging functions under io",
           "Fix run_cmd not collecting output on POSIX",
           "Improve trace logging"
-        ]
+        ],
+        "0.5.1": ["Fix run_cmd always outputting logs on success"]
       }
     }
   }

--- a/modules/petzku/util.moon
+++ b/modules/petzku/util.moon
@@ -12,7 +12,7 @@ local util, re
 if haveDepCtrl
     depctrl = DependencyControl {
         name: 'petzkuLib',
-        version: '0.5.0',
+        version: '0.5.1',
         description: [[Various utility functions for use with petzku's Aegisub macros]],
         author: "petzku",
         url: "https://github.com/petzku/Aegisub-Scripts",
@@ -170,13 +170,14 @@ with lib
 
             .io.trace "Using runner file: %s", runner_path
             
+            -- status is true if **successful**, unlike with system(3)
             status, reason, exit_code = os.execute runner_path
 
             f = io.open output_path
             output = f\read '*a'
             f\close!
 
-            LOG = .io.error if status
+            LOG = .io.error unless status
             LOG "Command Logs:"
             LOG
             LOG output


### PR DESCRIPTION
Stupidly assumed that `status` is false when the command is successful
