### PR TITLE
[Minesweeper] Major update (0.4.0)

### DIFF
--- a/macros/petzku.Minesweeper.moon
+++ b/macros/petzku.Minesweeper.moon
@@ -51,7 +51,7 @@ build_field = ->
     -- reveal starting square
     do
         -- prioritize picking an empty square, if possible
-        zeros = [{x,y} for x=1,WIDTH for y=1,HEIGHT when t[x][y].n == 0]
+        zeros = [{x,y} for x=1,WIDTH for y=1,HEIGHT when t[x][y].n == 0 and not t[x][y].mine]
         starts = if #zeros > 0 then zeros else
             [{x,y} for x=1,WIDTH for y=1,HEIGHT when not t[x][y].mine]
         i = math.random 1, #starts

--- a/macros/petzku.Minesweeper.moon
+++ b/macros/petzku.Minesweeper.moon
@@ -67,14 +67,14 @@ build_gui = (field, reveal) ->
     for c, col in ipairs field
         for r, cell in ipairs col
             x = if cell.flag
-                {x: c, y: r, height: 1, width: 1, class: "label", label: "🚩"}
+                {x: c-1, y: r, height: 1, width: 1, class: "label", label: "🚩"}
             elseif cell.hidden
                 unless reveal
-                    {x: c, y: r, height: 1, width: 1, class: "checkbox", value: false, name: "#{c}-#{r}", hint: "#{c}-#{r}"}
+                    {x: c-1, y: r, height: 1, width: 1, class: "checkbox", value: false, name: "#{c}-#{r}", hint: "#{c}-#{r}"}
                 else
-                    {x: c, y: r, height: 1, width: 1, class: "label", label: cell.mine and "💣" or " - "}
+                    {x: c-1, y: r, height: 1, width: 1, class: "label", label: cell.mine and "💣" or " - "}
             else
-                {x: c, y: r, height: 1, width: 1, class: "label", label: cell.mine and "💥" or "#{cell.n == 0 and '  ' or string.format "%2d ", cell.n}"}
+                {x: c-1, y: r, height: 1, width: 1, class: "label", label: cell.mine and "💥" or "#{cell.n == 0 and '  ' or string.format "%2d ", cell.n}"}
             table.insert t, x
     t
 

--- a/macros/petzku.Minesweeper.moon
+++ b/macros/petzku.Minesweeper.moon
@@ -7,6 +7,7 @@ export script_namespace =   "petzku.Minesweeper"
 export script_version =     "0.4.0"
 
 DIFFICULTIES = {
+    "&Trivial":         {w:  4, h:  4, m:  3}
     "&Beginner":        {w:  9, h:  9, m: 10}
     "&Intermediate":    {w: 16, h: 16, m: 40}
     "&Expert":          {w: 30, h: 16, m: 99}

--- a/macros/petzku.Minesweeper.moon
+++ b/macros/petzku.Minesweeper.moon
@@ -53,7 +53,6 @@ build_field = ->
     for m = 1, MINES
         i = math.random 1, #free_tiles
         x, y = unpack free_tiles[i]
-        continue if t[x][y].mine
         t[x][y].mine = true
         for i = -1,1
             for j = -1,1
@@ -62,6 +61,8 @@ build_field = ->
                 yy = y + j
                 continue if xx < 1 or yy < 1 or xx > WIDTH or yy > HEIGHT
                 t[xx][yy].n += 1
+        -- prevent double selection
+        table.remove free_tiles, i
 
     -- reveal starting square
     do

--- a/macros/petzku.Minesweeper.moon
+++ b/macros/petzku.Minesweeper.moon
@@ -13,9 +13,10 @@ MAXMINES = 10
 math.randomseed(os.time())
 
 _rev = (field, x, y) ->
-    return unless field[x][y].hidden
-    field[x][y].hidden = false
-    if field[x][y].n == 0
+    tile = field[x][y]
+    return unless tile.hidden
+    tile.hidden = false
+    if tile.n == 0 and not tile.mine
         -- cascade
         for i = -1,1
             for j = -1,1

--- a/macros/petzku.Minesweeper.moon
+++ b/macros/petzku.Minesweeper.moon
@@ -75,11 +75,23 @@ build_field = ->
         _rev t, x, y
     t
 
+_count_flags = (field) ->
+    flags = 0
+    for row in *field
+        for tile in *row
+            flags += 1 if tile.flag
+    flags
+
 build_gui = (field, reveal) ->
-    t = unless reveal
-        {{x: 0, y: 0, height: 1, width: 10, class: "label", label: "Let's play minesweeper!"}}
-    else
-        {{x: 0, y: 0, height: 1, width: 10, class: "label", label: reveal}}
+    flags = _count_flags field
+    t = {{
+        x: 0, y: 0, height: 1, width: 10, class: "label",
+        label: if reveal
+            reveal
+        elseif flags == 0
+            "Let's play minesweeper!"
+        else "Mines left: #{MINES-flags} / #{MINES}"
+    }}
     for c, col in ipairs field
         for r, cell in ipairs col
             x = if cell.flag

--- a/macros/petzku.Minesweeper.moon
+++ b/macros/petzku.Minesweeper.moon
@@ -6,9 +6,9 @@ export script_author =      "petzku"
 export script_namespace =   "petzku.Minesweeper"
 export script_version =     "0.3.0"
 
-WIDTH = 8
-HEIGHT = 8
-MAXMINES = 10
+WIDTH = 9
+HEIGHT = 9
+MINES = 10
 
 math.randomseed(os.time())
 
@@ -26,6 +26,21 @@ _rev = (field, x, y) ->
                 continue if xx < 1 or yy < 1 or xx > WIDTH or yy > HEIGHT
                 _rev field, xx, yy
 
+select_diff = ->
+    btn = aegisub.dialog.display {
+        {x: 0, y: 0, height: 1, width: 10, class: "label", label: "Choose your difficulty:"}
+    }, {"Beginner", "Intermediate", "Expert"}
+    export WIDTH, HEIGHT, MINES = if btn == "Beginner"
+        9, 9, 10
+    elseif btn == "Intermediate"
+        16, 16, 40
+    elseif btn == "Expert"
+        30, 16, 99
+    else
+        -- user clicked X or something
+        return false
+    true
+
 build_field = ->
     t = {}
     for i = 1,WIDTH
@@ -35,7 +50,7 @@ build_field = ->
 
     -- place mines
     free_tiles = [{x,y} for x=1,WIDTH for y=1,HEIGHT]
-    for m = 1, MAXMINES
+    for m = 1, MINES
         i = math.random 1, #free_tiles
         x, y = unpack free_tiles[i]
         continue if t[x][y].mine
@@ -125,7 +140,7 @@ check_win = (field) ->
             return false if x.hidden and not x.mine
     return true
 
-main = () ->
+main = ->
     f = build_field!
     win = false
     while not win
@@ -146,4 +161,8 @@ main = () ->
         win = check_win f
     aegisub.dialog.display (build_gui f, win and "You won!" or "You lost!"), {"&Close"}
 
-aegisub.register_macro script_name, script_description, main
+start = ->
+    -- select difficulty and play; if user presses X, quit immediately
+    main! if select_diff!
+
+aegisub.register_macro script_name, script_description, start

--- a/macros/petzku.Minesweeper.moon
+++ b/macros/petzku.Minesweeper.moon
@@ -4,13 +4,19 @@ export script_name =        "Minesweeper"
 export script_description = "Play Minesweeper. Why? Who knows."
 export script_author =      "petzku"
 export script_namespace =   "petzku.Minesweeper"
-export script_version =     "0.3.0"
+export script_version =     "0.4.0"
+
+DIFFICULTIES = {
+    "&Beginner":        {w:  9, h:  9, m: 10}
+    "&Intermediate":    {w: 16, h: 16, m: 40}
+    "&Expert":          {w: 30, h: 16, m: 99}
+}
 
 WIDTH = 9
 HEIGHT = 9
 MINES = 10
 
-math.randomseed(os.time())
+math.randomseed os.time!
 
 _rev = (field, x, y) ->
     tile = field[x][y]
@@ -29,13 +35,10 @@ _rev = (field, x, y) ->
 select_diff = ->
     btn = aegisub.dialog.display {
         {x: 0, y: 0, height: 1, width: 10, class: "label", label: "Choose your difficulty:"}
-    }, {"Beginner", "Intermediate", "Expert"}
-    export WIDTH, HEIGHT, MINES = if btn == "Beginner"
-        9, 9, 10
-    elseif btn == "Intermediate"
-        16, 16, 40
-    elseif btn == "Expert"
-        30, 16, 99
+    }, [name for name, v in pairs DIFFICULTIES]
+    diff = DIFFICULTIES[btn]
+    export WIDTH, HEIGHT, MINES = if diff
+        diff.w, diff.h, diff.m
     else
         -- user clicked X or something
         return false

--- a/macros/petzku.Minesweeper.moon
+++ b/macros/petzku.Minesweeper.moon
@@ -113,6 +113,12 @@ flag = (field, res) ->
         field[x][y].flag = true
     field
 
+remove_flags = (field) ->
+    for row in *field
+        for tile in *row
+            tile.flag = false
+    field
+
 check_win = (field) ->
     for col in *field
         for x in *col
@@ -123,13 +129,15 @@ main = () ->
     f = build_field!
     win = false
     while not win
-        btn, res = aegisub.dialog.display (build_gui f), {"&Reveal", "&Flag", "&Cancel"}, {ok: "&Reveal", cancel: "&Cancel"}
+        btn, res = aegisub.dialog.display (build_gui f), {"&Reveal", "&Flag", "&Clear flags", "&Quit"}, {ok: "&Reveal", cancel: "&Quit"}
         -- cancel = quit game
         break unless btn
         f, quit, msg = if btn == "&Reveal"
             reveal f, res
         elseif btn == "&Flag"
             flag f, res
+        elseif btn == "&Clear flags"
+            remove_flags f
         else
             f
         aegisub.log 3, msg if msg

--- a/macros/petzku.Minesweeper.moon
+++ b/macros/petzku.Minesweeper.moon
@@ -34,12 +34,11 @@ build_field = ->
             table.insert t[i], {hidden: true, mine: false, n: 0}
 
     -- place mines
-    m = 0
-    while m < MAXMINES
-        x = math.random 1, WIDTH
-        y = math.random 1, HEIGHT
+    free_tiles = [{x,y} for x=1,WIDTH for y=1,HEIGHT]
+    for m = 1, MAXMINES
+        i = math.random 1, #free_tiles
+        x, y = unpack free_tiles[i]
         continue if t[x][y].mine
-        m += 1
         t[x][y].mine = true
         for i = -1,1
             for j = -1,1
@@ -50,12 +49,14 @@ build_field = ->
                 t[xx][yy].n += 1
 
     -- reveal starting square
-    while true
-        x = math.random 1, WIDTH
-        y = math.random 1, HEIGHT
-        continue if t[x][y].mine
+    do
+        -- prioritize picking an empty square, if possible
+        zeros = [{x,y} for x=1,WIDTH for y=1,HEIGHT when t[x][y].n == 0]
+        starts = if #zeros > 0 then zeros else
+            [{x,y} for x=1,WIDTH for y=1,HEIGHT when not t[x][y].mine]
+        i = math.random 1, #starts
+        x, y = unpack starts[i]
         _rev t, x, y
-        break
     t
 
 build_gui = (field, reveal) ->


### PR DESCRIPTION
- Guarantee starting on a blank square if possible
- Don't cascade if hitting a mine
  - You still lost the game, but the results screen showed numbers around the clicked mine if it had no neighbors
- Allow flagging mines
  - Can only be cleared all at once via button; don't misclick
- Align grid to window left edge
- Add difficulty selection popup
  - Three presets as in classic minesweeper: Beginner, Intermediate, Expert
- Display tally of flags vs mines during game
- Refactor mine placement and starting square choice
  - Used to be random iteration until finding valid; now pops from list